### PR TITLE
Feat/config email

### DIFF
--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -34,7 +34,8 @@ router.get("/calendars", getCalendar, async (req, res) => {
 
         res.send({
           events: result.data.items.map(calendar => {
-            if (calendar.id === calendar_id_entry.data) {
+            if (calendar_id_entry &&
+              calendar.id === calendar_id_entry.data) {
               return {
                 id: calendar.id,
                 summary: calendar.summary,


### PR DESCRIPTION
Add a configuration endpoint (for admins only) to configure the Gmail credentials used to send emails.

This is still a temporary solution, but at least the Gmail credentials can be removed from the code.